### PR TITLE
chore: fulfill ts-jest babel-core peer dep explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/async": "2.0.49",
     "@types/jest": "23.3.1",
     "@types/node": "10.5.4",
+    "babel-core": "6.26.3",
     "commitlint": "7.0.0",
     "husky": "0.14.3",
     "jest": "23.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,7 +522,7 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.0.0, babel-core@^6.26.0:
+babel-core@6.26.3, babel-core@^6.0.0, babel-core@^6.26.0:
   version "6.26.3"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
   dependencies:


### PR DESCRIPTION
`ts-jest` changed moved `babel-core` to a peerDependency in
https://github.com/kulshekhar/ts-jest/pull/512/commits/8f94a611cae2bbf81d4f0eb910e2ca3838ad12c6
and while the dependency was still implicitly fulfilled because `ts-jest` still
depends on `jest-config` which also has a`babel-core` dependency it is probably
more stable to explicitly define `babel-core` as a dependency.