### PR TITLE
ci: switch to zenko/cloudserver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,24 @@ node_js:
 services:
   - docker
 
-env:
-  global:
-    # Default scality/s3server credentials
-    - AWS_ACCESS_KEY_ID=accessKey1 AWS_SECRET_ACCESS_KEY=verySecretKey1
-
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/
 
+env:
+  global:
+    - AWS_ACCESS_KEY_ID=accessKey1 AWS_SECRET_ACCESS_KEY=verySecretKey1
+
 before_install:
-  - docker run -d --name s3server -p 8000:8000 scality/s3server:mem-latest
+  - >
+    docker run
+    -d
+    --name cloudserver
+    -p 8000:8000
+    -e S3BACKEND=mem
+    -e SCALITY_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
+    -e SCALITY_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
+    zenko/cloudserver
 
 install:
   - yarn

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ integration level and need a S3 endpoint which is configurable through the
 `S3_ENDPOINT` environment variable.
 
 The tests are known to run successfully against
-[`scality/s3server`](https://hub.docker.com/r/scality/s3server/) and
+[`zenko/cloudserver`](https://hub.docker.com/r/zenko/cloudserver/) and
 obviously real AWS S3 (which nonetheless is not recommended due to cost and
 speed) while they are known to fail against
-[`localstack/localstack`](https://hub.docker.com/r/scality/s3server/) because
+[`localstack/localstack`](https://hub.docker.com/r/localstack/localstack/) because
 of bugs in its versioning implementation (though the library should still
 work on unversioned localstack buckets).
 


### PR DESCRIPTION
scality/s3server was renamed and the old image is no longer maintained